### PR TITLE
Avoids silent failures in deletion of datasets

### DIFF
--- a/bin/delete_bioentities_species.sh
+++ b/bin/delete_bioentities_species.sh
@@ -6,10 +6,15 @@ source $scriptDir/common_routines.sh
 require_env_var "SOLR_HOST"
 require_env_var "SPECIES"
 
-curl -X POST -H 'Content-Type: application/json' \
+HTTP_STATUS=$(curl -o >(cat >&3) -w "%{http_code}" -X POST -H 'Content-Type: application/json' \
 "http://$SOLR_HOST/solr/bioentities-v1/update/json?commit=true" --data-binary \
 '{
   "delete": {
     "query": "species:$SPECIES"
   }
-}'
+}')
+
+if [[ ! ${HTTP_STATUS} == 2* ]]
+then
+  echo "Error during delete!" && exit 1
+fi

--- a/tests/bioentities.bats
+++ b/tests/bioentities.bats
@@ -137,6 +137,20 @@ setup() {
   [ "${status}" -eq 0 ]
 }
 
+@test "[bioentities] Test failed deletion" {
+  if [ -z ${SOLR_HOST+x} ]; then
+    skip "SOLR_HOST not defined, skipping load to Solr"
+  fi
+  export SPECIES=homo_sapiens
+  export SOLR_HOST=fake-solr-host-to-fail
+
+  run delete_bioentities_species.sh
+
+  echo "output = ${output}"
+  [ "${status}" -eq 1 ]
+}
+
+
 @test "[bioentities] Load species into SOLR" {
   if [ -z ${SOLR_HOST+x} ]; then
     skip "SOLR_HOST not defined, skipping load to Solr"


### PR DESCRIPTION
Currently the deletion script was failing silently when given wrong credentials or collection name. This PR addresses that.