### PR TITLE
Configure bulk Expression Atlas suggesters non-destructively

### DIFF
--- a/bin/build-gxa-suggesters.sh
+++ b/bin/build-gxa-suggesters.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+. ${DIR}/schema-version.env
+
+# On developers environment export SOLR_HOST and export SOLR_COLLECTION before running
+HOST=${SOLR_HOST:-"localhost:8983"}
+COLLECTION=${SOLR_COLLECTION:-"bioentities-v${SCHEMA_VERSION}"}
+
+echo "Building gxa bioentities suggesters..."
+
+HTTP_STATUS=$(curl -w "%{http_code}" -o >(cat >&3) -s -o /dev/null "http://${HOST}/solr/${COLLECTION}/suggest?suggest.dictionary=propertySuggester&suggest.build=true")
+
+if [[ ! $HTTP_STATUS == 2* ]];
+then
+	 # HTTP Status is not a 2xx code
+   exit 1
+fi

--- a/bin/build-gxa-suggesters.sh
+++ b/bin/build-gxa-suggesters.sh
@@ -9,7 +9,7 @@ COLLECTION=${SOLR_COLLECTION:-"bioentities-v${SCHEMA_VERSION}"}
 
 echo "Building gxa bioentities suggesters..."
 
-HTTP_STATUS=$(curl -w "%{http_code}" -o >(cat >&3) -s -o /dev/null "http://${HOST}/solr/${COLLECTION}/suggest?suggest.dictionary=propertySuggester&suggest.build=true")
+HTTP_STATUS=$(curl -w "%{http_code}" -o >(cat >&3) -s "http://${HOST}/solr/${COLLECTION}/suggest?suggest.dictionary=propertySuggester&suggest.build=true")
 
 if [[ ! $HTTP_STATUS == 2* ]];
 then

--- a/bin/build-gxa-suggesters.sh
+++ b/bin/build-gxa-suggesters.sh
@@ -8,6 +8,8 @@ HOST=${SOLR_HOST:-"localhost:8983"}
 COLLECTION=${SOLR_COLLECTION:-"bioentities-v${SCHEMA_VERSION}"}
 
 echo "Building gxa bioentities suggesters..."
+# creates a new file descriptor 3 that redirects to 1 (STDOUT)
+exec 3>&1
 
 HTTP_STATUS=$(curl -w "%{http_code}" -o >(cat >&3) -s "http://${HOST}/solr/${COLLECTION}/suggest?suggest.dictionary=propertySuggester&suggest.build=true")
 

--- a/bin/create-bioentities-suggesters-gxa.sh
+++ b/bin/create-bioentities-suggesters-gxa.sh
@@ -9,14 +9,30 @@ COLLECTION=${SOLR_COLLECTION:-"bioentities-v${SCHEMA_VERSION}"}
 
 #############################################################################################
 
-printf "\n\nDelete request handler /suggest"
-curl -X POST -H 'Content-type:application/json' --data-binary '{
-  "delete-searchcomponent" : "suggest"
-}' http://${HOST}/solr/${COLLECTION}/config
-
-printf "\n\nCreate search component for suggesters"
+printf "\n\nCreate empty search component for suggesters if it does not exist...\n"
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-searchcomponent": {
+    "name": "suggest",
+    "class": "solr.SuggestComponent"
+  }
+}' http://${HOST}/solr/${COLLECTION}/config
+
+printf "\n\nClear suggester configuration for bulk Expression Atlas...\n"
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+  "update-searchcomponent": {
+    "name": "suggest",
+    "class": "solr.SuggestComponent",
+    "suggester": [
+      {
+        "name": "propertySuggester"
+      }
+    ]
+  }
+}' http://${HOST}/solr/${COLLECTION}/config
+
+printf "\n\nAdd suggester for bulk Expression Atlas...\n"
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+  "update-searchcomponent": {
     "name": "suggest",
     "class": "solr.SuggestComponent",
     "suggester": [
@@ -39,12 +55,12 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 
 #############################################################################################
 
-printf "\n\nDelete request handler /suggest"
+printf "\n\nDelete request handler /suggest...\n"
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-requesthandler" : "/suggest"
 }' http://${HOST}/solr/${COLLECTION}/config
 
-printf "\n\nCreate request handler /suggest"
+printf "\n\nCreate request handler /suggest...\n"
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-requesthandler" : {
     "name": "/suggest",

--- a/tests/bioentities-check-suggestions-gxa.sh
+++ b/tests/bioentities-check-suggestions-gxa.sh
@@ -8,9 +8,6 @@ set -e
 HOST=${SOLR_HOST:-"localhost:8983"}
 COLLECTION=${SOLR_COLLECTION:-"bioentities-v$SCHEMA_VERSION"}
 
-echo "Checking suggesters..."
-
-curl -s -o /dev/null "http://${HOST}/solr/${COLLECTION}/suggest?suggest.dictionary=propertySuggester&suggest.build=true"
 
 NUM_SUGGESTIONS=$(curl -s \
   "http://${HOST}/solr/${COLLECTION}/suggest?suggest.dictionary=propertySuggester&suggest.q=pseudo" | \

--- a/tests/bioentities.bats
+++ b/tests/bioentities.bats
@@ -77,16 +77,6 @@ setup() {
   [ "${status}" -eq 0 ]
 }
 
-@test "[bioentities] Check suggesters for Single Cell Expression Atlas have been properly created" {
-  if [ -z ${SOLR_HOST+x} ]; then
-    skip "SOLR_HOST not defined, skipping suggesters check"
-  fi
-  run create-bioentities-suggesters-scxa.sh
-  run bioentities-check-created-suggesters-scxa.sh
-  echo "output = ${output}"
-  [ "${status}" -eq 0 ]
-}
-
 @test "[bioentities] Build suggesters of known and unknown terms in bulk Expression Atlas" {
   if [ -z ${SOLR_HOST+x} ]; then
     skip "SOLR_HOST not defined, skipping suggestions of known gene symbol"
@@ -103,6 +93,16 @@ setup() {
   fi
   run bioentities-check-suggestions-gxa.sh
 
+  echo "output = ${output}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "[bioentities] Check suggesters for Single Cell Expression Atlas have been properly created" {
+  if [ -z ${SOLR_HOST+x} ]; then
+    skip "SOLR_HOST not defined, skipping suggesters check"
+  fi
+  run create-bioentities-suggesters-scxa.sh
+  run bioentities-check-created-suggesters-scxa.sh
   echo "output = ${output}"
   [ "${status}" -eq 0 ]
 }

--- a/tests/bioentities.bats
+++ b/tests/bioentities.bats
@@ -68,12 +68,11 @@ setup() {
   [ "${status}" -eq 0 ]
 }
 
-@test "[bioentities] Check suggesters for bulk Expression Atlas have been properly created" {
+@test "[bioentities] Create suggesters for bulk Expression Atlas" {
   if [ -z ${SOLR_HOST+x} ]; then
     skip "SOLR_HOST not defined, skipping suggesters check"
   fi
   run create-bioentities-suggesters-gxa.sh
-  run bioentities-check-created-suggesters-gxa.sh
   echo "output = ${output}"
   [ "${status}" -eq 0 ]
 }

--- a/tests/bioentities.bats
+++ b/tests/bioentities.bats
@@ -93,6 +93,7 @@ setup() {
     skip "SOLR_HOST not defined, skipping suggestions of known gene symbol"
   fi
   run create-bioentities-suggesters-gxa.sh
+  run build-gxa-suggesters.sh
   run bioentities-check-suggestions-gxa.sh
 
   echo "output = ${output}"

--- a/tests/bioentities.bats
+++ b/tests/bioentities.bats
@@ -88,12 +88,20 @@ setup() {
   [ "${status}" -eq 0 ]
 }
 
-@test "[bioentities] Check suggestions of known and unknown terms in bulk Expression Atlas" {
+@test "[bioentities] Build suggesters of known and unknown terms in bulk Expression Atlas" {
   if [ -z ${SOLR_HOST+x} ]; then
     skip "SOLR_HOST not defined, skipping suggestions of known gene symbol"
   fi
-  run create-bioentities-suggesters-gxa.sh
   run build-gxa-suggesters.sh
+
+  echo "output = ${output}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "[bioentities] Check suggesters of known and unknown terms in bulk Expression Atlas" {
+  if [ -z ${SOLR_HOST+x} ]; then
+    skip "SOLR_HOST not defined, skipping suggestions of known gene symbol"
+  fi
   run bioentities-check-suggestions-gxa.sh
 
   echo "output = ${output}"


### PR DESCRIPTION
The scripts deleted the search component that stored the suggesters, causing any suggester from Single Cell Expression Atlas to be removed in the process. With this revision, while the suggester isn’t entirely deleted, its configuration is completely cleared first to avoid any parameters to be kept between collection versions. As long as the name `proppertySuggester` is maintained it will work fine.

See also https://github.com/ebi-gene-expression-group/index-bioentities/pull/6.