### PR TITLE
Configure Single Cell Expression Atlas suggesters non-destructively

### DIFF
--- a/bin/build-scxa-suggesters.sh
+++ b/bin/build-scxa-suggesters.sh
@@ -11,7 +11,7 @@ echo "Building bioentities scxa suggesters..."
 
 status=0
 for suggester in propertySuggesterNoHighlight bioentitySuggester; do
-  HTTP_STATUS=$(curl -w "%{http_code}" -o >(cat >&3) -s -o /dev/null "http://${HOST}/solr/${COLLECTION}/suggest?suggest.dictionary=${suggester}&suggest.build=true")
+  HTTP_STATUS=$(curl -w "%{http_code}" -o >(cat >&3) -s "http://${HOST}/solr/${COLLECTION}/suggest?suggest.dictionary=${suggester}&suggest.build=true")
 
   if [[ ! $HTTP_STATUS == 2* ]];
   then

--- a/bin/build-scxa-suggesters.sh
+++ b/bin/build-scxa-suggesters.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+. ${DIR}/schema-version.env
+
+# On developers environment export SOLR_HOST and export SOLR_COLLECTION before running
+HOST=${SOLR_HOST:-"localhost:8983"}
+COLLECTION=${SOLR_COLLECTION:-"bioentities-v${SCHEMA_VERSION}"}
+
+echo "Building bioentities scxa suggesters..."
+
+status=0
+for suggester in propertySuggesterNoHighlight bioentitySuggester; do
+  HTTP_STATUS=$(curl -w "%{http_code}" -o >(cat >&3) -s -o /dev/null "http://${HOST}/solr/${COLLECTION}/suggest?suggest.dictionary=${suggester}&suggest.build=true")
+
+  if [[ ! $HTTP_STATUS == 2* ]];
+  then
+	   # HTTP Status is not a 2xx code
+     echo "Failed to build suggester $suggester"
+     status=1
+  fi
+done
+
+exit $status

--- a/bin/build-scxa-suggesters.sh
+++ b/bin/build-scxa-suggesters.sh
@@ -8,6 +8,8 @@ HOST=${SOLR_HOST:-"localhost:8983"}
 COLLECTION=${SOLR_COLLECTION:-"bioentities-v${SCHEMA_VERSION}"}
 
 echo "Building bioentities scxa suggesters..."
+# creates a new file descriptor 3 that redirects to 1 (STDOUT)
+exec 3>&1 
 
 status=0
 for suggester in propertySuggesterNoHighlight bioentitySuggester; do

--- a/bin/create-bioentities-suggesters-scxa.sh
+++ b/bin/create-bioentities-suggesters-scxa.sh
@@ -9,14 +9,33 @@ COLLECTION=${SOLR_COLLECTION:-"bioentities-v${SCHEMA_VERSION}"}
 
 #############################################################################################
 
-printf "\n\nDelete search component for suggesters"
-curl -X POST -H 'Content-type:application/json' --data-binary '{
-  "delete-searchcomponent" : "suggest"
-}' http://${HOST}/solr/${COLLECTION}/config
-
-printf "\n\nCreate search component for suggesters"
+printf "\n\nCreate empty search component for suggesters if it does not exist...\n"
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-searchcomponent": {
+    "name": "suggest",
+    "class": "solr.SuggestComponent"
+  }
+}' http://${HOST}/solr/${COLLECTION}/config
+
+printf "\n\nClear suggesters configuration for Single Cell Expression Atlas...\n"
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+  "update-searchcomponent": {
+    "name": "suggest",
+    "class": "solr.SuggestComponent",
+    "suggester": [
+      {
+        "name": "bioentitySuggester"
+      },
+      {
+        "name": "propertySuggesterNoHighlight"
+      }
+    ]
+  }
+}' http://${HOST}/solr/${COLLECTION}/config
+
+printf "\n\Add suggesters for Single Cell Expression Atlas...\n"
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+  "update-searchcomponent": {
     "name": "suggest",
     "class": "solr.SuggestComponent",
     "suggester": [
@@ -53,12 +72,12 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 
 #############################################################################################
 
-printf "\n\nDelete request handler /suggest"
+printf "\n\nDelete request handler /suggest...\n"
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-requesthandler" : "/suggest"
 }' http://${HOST}/solr/${COLLECTION}/config
 
-printf "\n\nCreate request handler /suggest"
+printf "\n\nCreate request handler /suggest...\n"
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-requesthandler" : {
     "name": "/suggest",

--- a/tests/bioentities-check-suggestions-scxa.sh
+++ b/tests/bioentities-check-suggestions-scxa.sh
@@ -10,8 +10,6 @@ COLLECTION=${SOLR_COLLECTION:-"bioentities-v$SCHEMA_VERSION"}
 
 echo "Checking suggesters..."
 
-curl -s -o /dev/null "http://${HOST}/solr/${COLLECTION}/suggest?suggest.dictionary=propertySuggesterNoHighlight&suggest.build=true"
-curl -s -o /dev/null "http://${HOST}/solr/${COLLECTION}/suggest?suggest.dictionary=bioentitySuggester&suggest.build=true"
 
 NUM_SUGGESTIONS=$(curl -s \
   "http://${HOST}/solr/${COLLECTION}/suggest?suggest.dictionary=propertySuggesterNoHighlight&suggest.q=pseudo" | \

--- a/tests/bioentities.bats
+++ b/tests/bioentities.bats
@@ -104,6 +104,7 @@ setup() {
     skip "SOLR_HOST not defined, skipping suggestions of known gene symbol"
   fi
   run create-bioentities-suggesters-scxa.sh
+  run build-scxa-suggesters.sh
   run bioentities-check-suggestions-scxa.sh
 
   echo "output = ${output}"

--- a/tests/bioentities.bats
+++ b/tests/bioentities.bats
@@ -99,12 +99,31 @@ setup() {
   [ "${status}" -eq 0 ]
 }
 
-@test "[bioentities] Check suggestions of known and unknown terms in Single Cell Expression Atlas" {
+@test "[bioentities] Create suggesters in Single Cell Expression Atlas" {
   if [ -z ${SOLR_HOST+x} ]; then
     skip "SOLR_HOST not defined, skipping suggestions of known gene symbol"
   fi
   run create-bioentities-suggesters-scxa.sh
+
+  echo "output = ${output}"
+  [ "${status}" -eq 0 ]
+}
+
+
+@test "[bioentities] Build suggesters of known and unknown terms in Single Cell Expression Atlas" {
+  if [ -z ${SOLR_HOST+x} ]; then
+    skip "SOLR_HOST not defined, skipping suggestions of known gene symbol"
+  fi
   run build-scxa-suggesters.sh
+
+  echo "output = ${output}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "[bioentities] Check suggesters of known and unknown terms in Single Cell Expression Atlas" {
+  if [ -z ${SOLR_HOST+x} ]; then
+    skip "SOLR_HOST not defined, skipping suggestions of known gene symbol"
+  fi
   run bioentities-check-suggestions-scxa.sh
 
   echo "output = ${output}"


### PR DESCRIPTION
The scripts deleted the search component that stored the suggesters, causing any suggester from bulk Expression Atlas to be removed in the process. With this revision, while the suggesters aren’t entirely deleted, their configurations are completely cleared first to avoid any parameters to be kept between collection versions. As long as the names `bioentitySuggester`  and `propertySuggesterNoHighlight` are maintained it will work fine.

See also https://github.com/ebi-gene-expression-group/index-bioentities/pull/5.