### PR TITLE
Fix bioentities deletion by species

### DIFF
--- a/bin/delete_bioentities_species.sh
+++ b/bin/delete_bioentities_species.sh
@@ -6,13 +6,13 @@ source $scriptDir/common_routines.sh
 require_env_var "SOLR_HOST"
 require_env_var "SPECIES"
 
-HTTP_STATUS=$(curl -o >(cat >&3) -w "%{http_code}" -X POST -H 'Content-Type: application/json' \
-"http://$SOLR_HOST/solr/bioentities-v1/update/json?commit=true" --data-binary \
-'{
-  "delete": {
-    "query": "species:$SPECIES"
-  }
-}')
+# creates a new file descriptor 3 that redirects to 1 (STDOUT)
+exec 3>&1
+
+HTTP_STATUS=$(curl -o >(cat >&3) -w "%{http_code}" -X POST -H "Content-Type: text/xml" \
+"http://$SOLR_HOST/solr/bioentities-v1/update?commit=true" --data-binary \
+"<delete><query>species:$SPECIES</query></delete>"
+)
 
 if [[ ! ${HTTP_STATUS} == 2* ]]
 then

--- a/tests/bioentities-check-species-is-deleted.sh
+++ b/tests/bioentities-check-species-is-deleted.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+. ${DIR}/../bin/schema-version.env
+
+set -e
+
+# on developers environment export SOLR_HOST_PORT and export SOLR_COLLECTION before running
+HOST=${SOLR_HOST:-"localhost:8983"}
+COLLECTION=${SOLR_COLLECTION:-"bioentities-v$SCHEMA_VERSION"}
+
+
+NUM_DOCS=$(curl -s \
+   http://wp-p3s-67:8983/solr/bioentities-v1/select?q=species:aegilops_tauschii
+  "http://${HOST}/solr/${COLLECTION}/select?q=species:$SPECIES" | \
+  jq '.response.numFound')
+if (( ${NUM_DOCS} > 0 ))
+then
+  echo "Documents found when querying for species $SPECIES, it should be empty after a succesful deletion."
+  exit 1
+fi

--- a/tests/bioentities.bats
+++ b/tests/bioentities.bats
@@ -155,6 +155,18 @@ setup() {
   [ "${status}" -eq 0 ]
 }
 
+@test "[bioentities] Check that species was deleted" {
+  if [ -z ${SOLR_HOST+x} ]; then
+    skip "SOLR_HOST not defined, skipping load to Solr"
+  fi
+  export SPECIES=homo_sapiens
+
+  run bioentities-check-species-is-deleted.sh
+
+  echo "output = ${output}"
+  [ "${status}" -eq 0 ]
+}
+
 @test "[bioentities] Test failed deletion" {
   if [ -z ${SOLR_HOST+x} ]; then
     skip "SOLR_HOST not defined, skipping load to Solr"


### PR DESCRIPTION
Bioentities deletion by species was broken due to a game of quotations, where the $SPECIES env var was never evaluated as it was single quoted due to the JSON structure being used. This PR fixes that and test that the deletions work.