### PR TITLE
Optimise bioentities and test executable in mac M1

### DIFF
--- a/bin/optimise-bioentities.sh
+++ b/bin/optimise-bioentities.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+. ${DIR}/schema-version.env
+
+# On developers environment export SOLR_HOST and export SOLR_COLLECTION before running
+HOST=${SOLR_HOST:-"localhost:8983"}
+COLLECTION=${SOLR_COLLECTION:-"bioentities-v${SCHEMA_VERSION}"}
+
+echo "Optimising bioentities..."
+# creates a new file descriptor 3 that redirects to 1 (STDOUT)
+exec 3>&1
+
+HTTP_STATUS=$(curl -w "%{http_code}" -o >(cat >&3) -s "http://${HOST}/solr/${COLLECTION}/update?optimize=true")
+
+if [[ ! $HTTP_STATUS == 2* ]];
+then
+	 # HTTP Status is not a 2xx code
+   exit 1
+fi

--- a/tests/bioentities-check-optimisation.sh
+++ b/tests/bioentities-check-optimisation.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+HOST=${SOLR_HOST:-"localhost:8983"}
+COLLECTION=${SOLR_COLLECTION:-"bioentities-v$SCHEMA_VERSION"}
+
+curl "http://${SOLR_HOST}/solr/admin/collections?action=CLUSTERSTATUS&collection=${COLLECTION}" | jq '..|.replicas? | select( . != null ) | to_entries | .[] | .value | (.base_url|tostring)+"/admin/cores?action=STATUS&core="+(.core|tostring)' | xargs curl -s | jq '..|.deletedDocs? | select( . != null )' | uniq

--- a/tests/bioentities.bats
+++ b/tests/bioentities.bats
@@ -209,6 +209,19 @@ setup() {
   [ "${status}" -eq 0 ]
 }
 
+@test "[bioentities] Check that optimisation worked" {
+  if [ -z ${SOLR_HOST+x} ]; then
+    skip "SOLR_HOST not defined, skipping load to Solr"
+  fi
+  COLLECTION=bioentities-v1
+
+  # result stores the number of deletedDocs for each core/shard of the collection
+  run curl "http://${SOLR_HOST}/solr/admin/collections?action=CLUSTERSTATUS&collection=${COLLECTION}" | jq '..|.replicas? | select( . != null ) | to_entries | .[] | .value | (.base_url|tostring)+"/admin/cores?action=STATUS&core="+(.core|tostring)' | xargs curl -s | jq '..|.deletedDocs? | select( . != null )' | uniq
+
+  echo "output = ${output}"
+  [ "${result}" -eq 0 ]
+}
+
 @test "[bioentities] Make mappings from bioentities for experiments" {
   # This uses experiments in tests/fixtures/experiment_files/magetab
   # that are compatible with the fixtures/bioentity_properties/homo_sapiens.ensgene.tsv

--- a/tests/bioentities.bats
+++ b/tests/bioentities.bats
@@ -213,13 +213,10 @@ setup() {
   if [ -z ${SOLR_HOST+x} ]; then
     skip "SOLR_HOST not defined, skipping load to Solr"
   fi
-  COLLECTION=bioentities-v1
-
-  # result stores the number of deletedDocs for each core/shard of the collection
-  run curl "http://${SOLR_HOST}/solr/admin/collections?action=CLUSTERSTATUS&collection=${COLLECTION}" | jq '..|.replicas? | select( . != null ) | to_entries | .[] | .value | (.base_url|tostring)+"/admin/cores?action=STATUS&core="+(.core|tostring)' | xargs curl -s | jq '..|.deletedDocs? | select( . != null )' | uniq
+  run bioentities-check-optimisation.sh
 
   echo "output = ${output}"
-  [ "${result}" -eq 0 ]
+  [ "${status}" -eq 0 ]
 }
 
 @test "[bioentities] Make mappings from bioentities for experiments" {

--- a/tests/bioentities.bats
+++ b/tests/bioentities.bats
@@ -198,6 +198,17 @@ setup() {
   [ "${status}" -eq 0 ]
 }
 
+@test "[bioentities] Optimise collection" {
+  if [ -z ${SOLR_HOST+x} ]; then
+    skip "SOLR_HOST not defined, skipping load to Solr"
+  fi
+
+  run optimise-bioentities.sh
+
+  echo "output = ${output}"
+  [ "${status}" -eq 0 ]
+}
+
 @test "[bioentities] Make mappings from bioentities for experiments" {
   # This uses experiments in tests/fixtures/experiment_files/magetab
   # that are compatible with the fixtures/bioentity_properties/homo_sapiens.ensgene.tsv


### PR DESCRIPTION
Adds logic for optimising bioentities collection after filling it.

I also ended up adding support for testing on M1 macs:
- Add docker platform line to run some containers as linux/amd64 when the container is only available for x86.
- Use tags that are available both for x86/amd64 and arm64 (M1), then it pulls the correct one for the arch.