### PR TITLE
Delete existing search component for suggesters

### DIFF
--- a/bin/create-bioentities-suggesters.sh
+++ b/bin/create-bioentities-suggesters.sh
@@ -12,6 +12,14 @@ COLLECTION=${SOLR_COLLECTION:-"bioentities-v${SCHEMA_VERSION}"}
 
 #############################################################################################
 
+printf "\n\nDelete search component for suggesters...\n"
+curl $SOLR_AUTH -X POST -H 'Content-type:application/json' --data-binary '{
+  "delete-searchcomponent": {
+    "name": "suggest",
+    "class": "solr.SuggestComponent"
+  }
+}' http://${HOST}/solr/${COLLECTION}/config
+
 printf "\n\nCreate empty search component for suggesters if it does not exist...\n"
 curl $SOLR_AUTH -X POST -H 'Content-type:application/json' --data-binary '{
   "add-searchcomponent": {

--- a/bin/create-bioentities-suggesters.sh
+++ b/bin/create-bioentities-suggesters.sh
@@ -14,10 +14,7 @@ COLLECTION=${SOLR_COLLECTION:-"bioentities-v${SCHEMA_VERSION}"}
 
 printf "\n\nDelete search component for suggesters...\n"
 curl $SOLR_AUTH -X POST -H 'Content-type:application/json' --data-binary '{
-  "delete-searchcomponent": {
-    "name": "suggest",
-    "class": "solr.SuggestComponent"
-  }
+  "delete-searchcomponent": "suggest"
 }' http://${HOST}/solr/${COLLECTION}/config
 
 printf "\n\nCreate empty search component for suggesters if it does not exist...\n"

--- a/bin/create-bioentities-suggesters.sh
+++ b/bin/create-bioentities-suggesters.sh
@@ -13,20 +13,20 @@ COLLECTION=${SOLR_COLLECTION:-"bioentities-v${SCHEMA_VERSION}"}
 #############################################################################################
 
 printf "\n\nDelete search component for suggesters...\n"
-curl $SOLR_AUTH -X POST -H 'Content-type:application/json' --data-binary '{
+curl "$SOLR_AUTH" -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-searchcomponent": "suggest"
-}' http://${HOST}/solr/${COLLECTION}/config
+}' "http://${HOST}/solr/${COLLECTION}/config" || { echo "Error: Failed to delete search component." >&2; exit 1; }
 
 printf "\n\nCreate empty search component for suggesters if it does not exist...\n"
-curl $SOLR_AUTH -X POST -H 'Content-type:application/json' --data-binary '{
+curl "$SOLR_AUTH" -X POST -H 'Content-type:application/json' --data-binary '{
   "add-searchcomponent": {
     "name": "suggest",
     "class": "solr.SuggestComponent"
   }
-}' http://${HOST}/solr/${COLLECTION}/config
+}' "http://${HOST}/solr/${COLLECTION}/config"  || { echo "Error: Failed to create empty search component for suggesters." >&2; exit 1; }
 
 printf "\n\nClear suggester configuration for SCXA and GXA...\n"
-curl $SOLR_AUTH -X POST -H 'Content-type:application/json' --data-binary '{
+curl "$SOLR_AUTH" -X POST -H 'Content-type:application/json' --data-binary '{
   "update-searchcomponent": {
     "name": "suggest",
     "class": "solr.SuggestComponent",
@@ -42,10 +42,10 @@ curl $SOLR_AUTH -X POST -H 'Content-type:application/json' --data-binary '{
       }
     ]
   }
-}' http://${HOST}/solr/${COLLECTION}/config
+}' "http://${HOST}/solr/${COLLECTION}/config" || { echo "Error: Failed to clear suggester configuration for SCXA and GXA." >&2; exit 1; }
 
 printf "\n\nAdd suggester for GXA and SCXA...\n"
-curl $SOLR_AUTH -X POST -H 'Content-type:application/json' --data-binary '{
+curl "$SOLR_AUTH" -X POST -H 'Content-type:application/json' --data-binary '{
   "update-searchcomponent": {
     "name": "suggest",
     "class": "solr.SuggestComponent",
@@ -92,17 +92,17 @@ curl $SOLR_AUTH -X POST -H 'Content-type:application/json' --data-binary '{
       }
     ]
   }
-}' http://${HOST}/solr/${COLLECTION}/config
+}' "http://${HOST}/solr/${COLLECTION}/config" || { echo "Error: Failed to dd suggester for GXA and SCXA." >&2; exit 1; }
 
 #############################################################################################
 
 printf "\n\nDelete request handler /suggest...\n"
-curl $SOLR_AUTH -X POST -H 'Content-type:application/json' --data-binary '{
+curl "$SOLR_AUTH" -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-requesthandler" : "/suggest"
-}' http://${HOST}/solr/${COLLECTION}/config
+}' "http://${HOST}/solr/${COLLECTION}/config" || { echo "Error: Failed to elete drequest handler /suggest." >&2; exit 1; }
 
 printf "\n\nCreate request handler /suggest...\n"
-curl $SOLR_AUTH -X POST -H 'Content-type:application/json' --data-binary '{
+curl "$SOLR_AUTH" -X POST -H 'Content-type:application/json' --data-binary '{
   "add-requesthandler" : {
     "name": "/suggest",
     "class": "solr.SearchHandler",
@@ -114,4 +114,4 @@ curl $SOLR_AUTH -X POST -H 'Content-type:application/json' --data-binary '{
       },
     "components": ["suggest"]
   }
-}' http://${HOST}/solr/${COLLECTION}/config
+}' "http://${HOST}/solr/${COLLECTION}/config" || { echo "Error: Failed to create request handler /suggest." >&2; exit 1; }


### PR DESCRIPTION
Changes here aim to address an error encountered when building suggesters for bulk bioentities in Solr 8.  The error is 
```
"errorMessages":[" 'suggest' already exists . Do an 'update-searchcomponent' , if you want to change it "]}]
``